### PR TITLE
Update to v2 API; accept stemcell and contract version

### DIFF
--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -14,8 +14,8 @@ func NewActionFactory(cpiFactory CPIFactory) ActionFactory {
 	return ActionFactory{cpiFactory}
 }
 
-func (f ActionFactory) Create(method string, context CallContext) (interface{}, error) {
-	cpi, err := f.cpiFactory.New(context)
+func (f ActionFactory) Create(method string, context CallContext, apiVersions ApiVersions) (interface{}, error) {
+	cpi, err := f.cpiFactory.New(context, apiVersions)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (f ActionFactory) Create(method string, context CallContext) (interface{}, 
 	case "create_vm":
 		return func(
 			agentID AgentID, stemcellCID StemcellCID, props CloudPropsImpl,
-			networks Networks, diskCIDs []DiskCID, env VMEnv) (VMCID, error) {
+			networks Networks, diskCIDs []DiskCID, env VMEnv) (interface{}, error) {
 
 			return cpi.CreateVM(agentID, stemcellCID, props, networks, diskCIDs, env)
 		}, nil
@@ -86,7 +86,7 @@ func (f ActionFactory) Create(method string, context CallContext) (interface{}, 
 
 	case "attach_disk":
 		return func(vmCID VMCID, diskCID DiskCID) (interface{}, error) {
-			return nil, cpi.AttachDisk(vmCID, diskCID)
+			return cpi.AttachDisk(vmCID, diskCID)
 		}, nil
 
 	case "detach_disk":

--- a/apiv1/apiv1fakes/fake_cpi.go
+++ b/apiv1/apiv1fakes/fake_cpi.go
@@ -33,16 +33,7 @@ type FakeCPI struct {
 	deleteStemcellReturns struct {
 		result1 error
 	}
-	CalculateVMCloudPropertiesStub        func(apiv1.VMResources) (apiv1.VMCloudProps, error)
-	calculateVMCloudPropertiesMutex       sync.RWMutex
-	calculateVMCloudPropertiesArgsForCall []struct {
-		arg1 apiv1.VMResources
-	}
-	calculateVMCloudPropertiesReturns struct {
-		result1 apiv1.VMCloudProps
-		result2 error
-	}
-	CreateVMStub        func(apiv1.AgentID, apiv1.StemcellCID, apiv1.VMCloudProps, apiv1.Networks, []apiv1.DiskCID, apiv1.VMEnv) (apiv1.VMCID, error)
+	CreateVMStub        func(apiv1.AgentID, apiv1.StemcellCID, apiv1.VMCloudProps, apiv1.Networks, []apiv1.DiskCID, apiv1.VMEnv) (interface{}, error)
 	createVMMutex       sync.RWMutex
 	createVMArgsForCall []struct {
 		arg1 apiv1.AgentID
@@ -53,7 +44,7 @@ type FakeCPI struct {
 		arg6 apiv1.VMEnv
 	}
 	createVMReturns struct {
-		result1 apiv1.VMCID
+		result1 interface{}
 		result2 error
 	}
 	DeleteVMStub        func(apiv1.VMCID) error
@@ -63,6 +54,15 @@ type FakeCPI struct {
 	}
 	deleteVMReturns struct {
 		result1 error
+	}
+	CalculateVMCloudPropertiesStub        func(apiv1.VMResources) (apiv1.VMCloudProps, error)
+	calculateVMCloudPropertiesMutex       sync.RWMutex
+	calculateVMCloudPropertiesArgsForCall []struct {
+		arg1 apiv1.VMResources
+	}
+	calculateVMCloudPropertiesReturns struct {
+		result1 apiv1.VMCloudProps
+		result2 error
 	}
 	SetVMMetadataStub        func(apiv1.VMCID, apiv1.VMMeta) error
 	setVMMetadataMutex       sync.RWMutex
@@ -118,14 +118,15 @@ type FakeCPI struct {
 	deleteDiskReturns struct {
 		result1 error
 	}
-	AttachDiskStub        func(apiv1.VMCID, apiv1.DiskCID) error
+	AttachDiskStub        func(apiv1.VMCID, apiv1.DiskCID) (interface{}, error)
 	attachDiskMutex       sync.RWMutex
 	attachDiskArgsForCall []struct {
 		arg1 apiv1.VMCID
 		arg2 apiv1.DiskCID
 	}
 	attachDiskReturns struct {
-		result1 error
+		result1 interface{}
+		result2 error
 	}
 	DetachDiskStub        func(apiv1.VMCID, apiv1.DiskCID) error
 	detachDiskMutex       sync.RWMutex
@@ -156,8 +157,9 @@ func (fake *FakeCPI) Info() (apiv1.Info, error) {
 	fake.infoMutex.Unlock()
 	if fake.InfoStub != nil {
 		return fake.InfoStub()
+	} else {
+		return fake.infoReturns.result1, fake.infoReturns.result2
 	}
-	return fake.infoReturns.result1, fake.infoReturns.result2
 }
 
 func (fake *FakeCPI) InfoCallCount() int {
@@ -184,8 +186,9 @@ func (fake *FakeCPI) CreateStemcell(arg1 string, arg2 apiv1.StemcellCloudProps) 
 	fake.createStemcellMutex.Unlock()
 	if fake.CreateStemcellStub != nil {
 		return fake.CreateStemcellStub(arg1, arg2)
+	} else {
+		return fake.createStemcellReturns.result1, fake.createStemcellReturns.result2
 	}
-	return fake.createStemcellReturns.result1, fake.createStemcellReturns.result2
 }
 
 func (fake *FakeCPI) CreateStemcellCallCount() int {
@@ -217,8 +220,9 @@ func (fake *FakeCPI) DeleteStemcell(arg1 apiv1.StemcellCID) error {
 	fake.deleteStemcellMutex.Unlock()
 	if fake.DeleteStemcellStub != nil {
 		return fake.DeleteStemcellStub(arg1)
+	} else {
+		return fake.deleteStemcellReturns.result1
 	}
-	return fake.deleteStemcellReturns.result1
 }
 
 func (fake *FakeCPI) DeleteStemcellCallCount() int {
@@ -240,7 +244,7 @@ func (fake *FakeCPI) DeleteStemcellReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCPI) CreateVM(arg1 apiv1.AgentID, arg2 apiv1.StemcellCID, arg3 apiv1.VMCloudProps, arg4 apiv1.Networks, arg5 []apiv1.DiskCID, arg6 apiv1.VMEnv) (apiv1.VMCID, error) {
+func (fake *FakeCPI) CreateVM(arg1 apiv1.AgentID, arg2 apiv1.StemcellCID, arg3 apiv1.VMCloudProps, arg4 apiv1.Networks, arg5 []apiv1.DiskCID, arg6 apiv1.VMEnv) (interface{}, error) {
 	var arg5Copy []apiv1.DiskCID
 	if arg5 != nil {
 		arg5Copy = make([]apiv1.DiskCID, len(arg5))
@@ -259,8 +263,9 @@ func (fake *FakeCPI) CreateVM(arg1 apiv1.AgentID, arg2 apiv1.StemcellCID, arg3 a
 	fake.createVMMutex.Unlock()
 	if fake.CreateVMStub != nil {
 		return fake.CreateVMStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	} else {
+		return fake.createVMReturns.result1, fake.createVMReturns.result2
 	}
-	return fake.createVMReturns.result1, fake.createVMReturns.result2
 }
 
 func (fake *FakeCPI) CreateVMCallCount() int {
@@ -275,10 +280,10 @@ func (fake *FakeCPI) CreateVMArgsForCall(i int) (apiv1.AgentID, apiv1.StemcellCI
 	return fake.createVMArgsForCall[i].arg1, fake.createVMArgsForCall[i].arg2, fake.createVMArgsForCall[i].arg3, fake.createVMArgsForCall[i].arg4, fake.createVMArgsForCall[i].arg5, fake.createVMArgsForCall[i].arg6
 }
 
-func (fake *FakeCPI) CreateVMReturns(result1 apiv1.VMCID, result2 error) {
+func (fake *FakeCPI) CreateVMReturns(result1 interface{}, result2 error) {
 	fake.CreateVMStub = nil
 	fake.createVMReturns = struct {
-		result1 apiv1.VMCID
+		result1 interface{}
 		result2 error
 	}{result1, result2}
 }
@@ -292,8 +297,9 @@ func (fake *FakeCPI) DeleteVM(arg1 apiv1.VMCID) error {
 	fake.deleteVMMutex.Unlock()
 	if fake.DeleteVMStub != nil {
 		return fake.DeleteVMStub(arg1)
+	} else {
+		return fake.deleteVMReturns.result1
 	}
-	return fake.deleteVMReturns.result1
 }
 
 func (fake *FakeCPI) DeleteVMCallCount() int {
@@ -324,8 +330,9 @@ func (fake *FakeCPI) CalculateVMCloudProperties(arg1 apiv1.VMResources) (apiv1.V
 	fake.calculateVMCloudPropertiesMutex.Unlock()
 	if fake.CalculateVMCloudPropertiesStub != nil {
 		return fake.CalculateVMCloudPropertiesStub(arg1)
+	} else {
+		return fake.calculateVMCloudPropertiesReturns.result1, fake.calculateVMCloudPropertiesReturns.result2
 	}
-	return fake.calculateVMCloudPropertiesReturns.result1, fake.calculateVMCloudPropertiesReturns.result2
 }
 
 func (fake *FakeCPI) CalculateVMCloudPropertiesCallCount() int {
@@ -358,8 +365,9 @@ func (fake *FakeCPI) SetVMMetadata(arg1 apiv1.VMCID, arg2 apiv1.VMMeta) error {
 	fake.setVMMetadataMutex.Unlock()
 	if fake.SetVMMetadataStub != nil {
 		return fake.SetVMMetadataStub(arg1, arg2)
+	} else {
+		return fake.setVMMetadataReturns.result1
 	}
-	return fake.setVMMetadataReturns.result1
 }
 
 func (fake *FakeCPI) SetVMMetadataCallCount() int {
@@ -390,8 +398,9 @@ func (fake *FakeCPI) HasVM(arg1 apiv1.VMCID) (bool, error) {
 	fake.hasVMMutex.Unlock()
 	if fake.HasVMStub != nil {
 		return fake.HasVMStub(arg1)
+	} else {
+		return fake.hasVMReturns.result1, fake.hasVMReturns.result2
 	}
-	return fake.hasVMReturns.result1, fake.hasVMReturns.result2
 }
 
 func (fake *FakeCPI) HasVMCallCount() int {
@@ -423,8 +432,9 @@ func (fake *FakeCPI) RebootVM(arg1 apiv1.VMCID) error {
 	fake.rebootVMMutex.Unlock()
 	if fake.RebootVMStub != nil {
 		return fake.RebootVMStub(arg1)
+	} else {
+		return fake.rebootVMReturns.result1
 	}
-	return fake.rebootVMReturns.result1
 }
 
 func (fake *FakeCPI) RebootVMCallCount() int {
@@ -455,8 +465,9 @@ func (fake *FakeCPI) GetDisks(arg1 apiv1.VMCID) ([]apiv1.DiskCID, error) {
 	fake.getDisksMutex.Unlock()
 	if fake.GetDisksStub != nil {
 		return fake.GetDisksStub(arg1)
+	} else {
+		return fake.getDisksReturns.result1, fake.getDisksReturns.result2
 	}
-	return fake.getDisksReturns.result1, fake.getDisksReturns.result2
 }
 
 func (fake *FakeCPI) GetDisksCallCount() int {
@@ -490,8 +501,9 @@ func (fake *FakeCPI) CreateDisk(arg1 int, arg2 apiv1.DiskCloudProps, arg3 *apiv1
 	fake.createDiskMutex.Unlock()
 	if fake.CreateDiskStub != nil {
 		return fake.CreateDiskStub(arg1, arg2, arg3)
+	} else {
+		return fake.createDiskReturns.result1, fake.createDiskReturns.result2
 	}
-	return fake.createDiskReturns.result1, fake.createDiskReturns.result2
 }
 
 func (fake *FakeCPI) CreateDiskCallCount() int {
@@ -523,8 +535,9 @@ func (fake *FakeCPI) DeleteDisk(arg1 apiv1.DiskCID) error {
 	fake.deleteDiskMutex.Unlock()
 	if fake.DeleteDiskStub != nil {
 		return fake.DeleteDiskStub(arg1)
+	} else {
+		return fake.deleteDiskReturns.result1
 	}
-	return fake.deleteDiskReturns.result1
 }
 
 func (fake *FakeCPI) DeleteDiskCallCount() int {
@@ -546,7 +559,7 @@ func (fake *FakeCPI) DeleteDiskReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCPI) AttachDisk(arg1 apiv1.VMCID, arg2 apiv1.DiskCID) error {
+func (fake *FakeCPI) AttachDisk(arg1 apiv1.VMCID, arg2 apiv1.DiskCID) (interface{}, error) {
 	fake.attachDiskMutex.Lock()
 	fake.attachDiskArgsForCall = append(fake.attachDiskArgsForCall, struct {
 		arg1 apiv1.VMCID
@@ -556,8 +569,9 @@ func (fake *FakeCPI) AttachDisk(arg1 apiv1.VMCID, arg2 apiv1.DiskCID) error {
 	fake.attachDiskMutex.Unlock()
 	if fake.AttachDiskStub != nil {
 		return fake.AttachDiskStub(arg1, arg2)
+	} else {
+		return fake.attachDiskReturns.result1, fake.attachDiskReturns.result2
 	}
-	return fake.attachDiskReturns.result1
 }
 
 func (fake *FakeCPI) AttachDiskCallCount() int {
@@ -572,11 +586,12 @@ func (fake *FakeCPI) AttachDiskArgsForCall(i int) (apiv1.VMCID, apiv1.DiskCID) {
 	return fake.attachDiskArgsForCall[i].arg1, fake.attachDiskArgsForCall[i].arg2
 }
 
-func (fake *FakeCPI) AttachDiskReturns(result1 error) {
+func (fake *FakeCPI) AttachDiskReturns(result1 interface{}, result2 error) {
 	fake.AttachDiskStub = nil
 	fake.attachDiskReturns = struct {
-		result1 error
-	}{result1}
+		result1 interface{}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCPI) DetachDisk(arg1 apiv1.VMCID, arg2 apiv1.DiskCID) error {
@@ -589,8 +604,9 @@ func (fake *FakeCPI) DetachDisk(arg1 apiv1.VMCID, arg2 apiv1.DiskCID) error {
 	fake.detachDiskMutex.Unlock()
 	if fake.DetachDiskStub != nil {
 		return fake.DetachDiskStub(arg1, arg2)
+	} else {
+		return fake.detachDiskReturns.result1
 	}
-	return fake.detachDiskReturns.result1
 }
 
 func (fake *FakeCPI) DetachDiskCallCount() int {
@@ -621,8 +637,9 @@ func (fake *FakeCPI) HasDisk(arg1 apiv1.DiskCID) (bool, error) {
 	fake.hasDiskMutex.Unlock()
 	if fake.HasDiskStub != nil {
 		return fake.HasDiskStub(arg1)
+	} else {
+		return fake.hasDiskReturns.result1, fake.hasDiskReturns.result2
 	}
-	return fake.hasDiskReturns.result1, fake.hasDiskReturns.result2
 }
 
 func (fake *FakeCPI) HasDiskCallCount() int {
@@ -658,6 +675,8 @@ func (fake *FakeCPI) Invocations() map[string][][]interface{} {
 	defer fake.createVMMutex.RUnlock()
 	fake.deleteVMMutex.RLock()
 	defer fake.deleteVMMutex.RUnlock()
+	fake.calculateVMCloudPropertiesMutex.RLock()
+	defer fake.calculateVMCloudPropertiesMutex.RUnlock()
 	fake.setVMMetadataMutex.RLock()
 	defer fake.setVMMetadataMutex.RUnlock()
 	fake.hasVMMutex.RLock()

--- a/apiv1/apiv1fakes/fake_cpifactory.go
+++ b/apiv1/apiv1fakes/fake_cpifactory.go
@@ -8,10 +8,11 @@ import (
 )
 
 type FakeCPIFactory struct {
-	NewStub        func(apiv1.CallContext) (apiv1.CPI, error)
+	NewStub        func(apiv1.CallContext, apiv1.ApiVersions) (apiv1.CPI, error)
 	newMutex       sync.RWMutex
 	newArgsForCall []struct {
 		arg1 apiv1.CallContext
+		arg2 apiv1.ApiVersions
 	}
 	newReturns struct {
 		result1 apiv1.CPI
@@ -21,17 +22,19 @@ type FakeCPIFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCPIFactory) New(arg1 apiv1.CallContext) (apiv1.CPI, error) {
+func (fake *FakeCPIFactory) New(arg1 apiv1.CallContext, arg2 apiv1.ApiVersions) (apiv1.CPI, error) {
 	fake.newMutex.Lock()
 	fake.newArgsForCall = append(fake.newArgsForCall, struct {
 		arg1 apiv1.CallContext
-	}{arg1})
-	fake.recordInvocation("New", []interface{}{arg1})
+		arg2 apiv1.ApiVersions
+	}{arg1, arg2})
+	fake.recordInvocation("New", []interface{}{arg1, arg2})
 	fake.newMutex.Unlock()
 	if fake.NewStub != nil {
-		return fake.NewStub(arg1)
+		return fake.NewStub(arg1, arg2)
+	} else {
+		return fake.newReturns.result1, fake.newReturns.result2
 	}
-	return fake.newReturns.result1, fake.newReturns.result2
 }
 
 func (fake *FakeCPIFactory) NewCallCount() int {
@@ -40,10 +43,10 @@ func (fake *FakeCPIFactory) NewCallCount() int {
 	return len(fake.newArgsForCall)
 }
 
-func (fake *FakeCPIFactory) NewArgsForCall(i int) apiv1.CallContext {
+func (fake *FakeCPIFactory) NewArgsForCall(i int) (apiv1.CallContext, apiv1.ApiVersions) {
 	fake.newMutex.RLock()
 	defer fake.newMutex.RUnlock()
-	return fake.newArgsForCall[i].arg1
+	return fake.newArgsForCall[i].arg1, fake.newArgsForCall[i].arg2
 }
 
 func (fake *FakeCPIFactory) NewReturns(result1 apiv1.CPI, result2 error) {

--- a/apiv1/disks.go
+++ b/apiv1/disks.go
@@ -4,7 +4,7 @@ type Disks interface {
 	CreateDisk(int, DiskCloudProps, *VMCID) (DiskCID, error)
 	DeleteDisk(DiskCID) error
 
-	AttachDisk(VMCID, DiskCID) error
+	AttachDisk(VMCID, DiskCID) (interface{}, error)
 	DetachDisk(VMCID, DiskCID) error
 
 	HasDisk(DiskCID) (bool, error)

--- a/apiv1/interfaces.go
+++ b/apiv1/interfaces.go
@@ -1,7 +1,12 @@
 package apiv1
 
+//go:generate counterfeiter -o apiv1fakes/fake_cpi.go . CPI
+//go:generate counterfeiter -o apiv1fakes/fake_cpifactory.go . CPIFactory
+
+const MaxSupportedApiVersion = 2
+
 type CPIFactory interface {
-	New(CallContext) (CPI, error)
+	New(CallContext, ApiVersions) (CPI, error)
 }
 
 type CallContext interface {
@@ -18,4 +23,10 @@ type CPI interface {
 
 type Info struct {
 	StemcellFormats []string `json:"stemcell_formats"`
+	ApiVersion      int      `json:"api_version,omitempty"`
+}
+
+type ApiVersions struct {
+	Stemcell int
+	Contract int
 }

--- a/apiv1/vms.go
+++ b/apiv1/vms.go
@@ -1,7 +1,7 @@
 package apiv1
 
 type VMs interface {
-	CreateVM(AgentID, StemcellCID, VMCloudProps, Networks, []DiskCID, VMEnv) (VMCID, error)
+	CreateVM(AgentID, StemcellCID, VMCloudProps, Networks, []DiskCID, VMEnv) (interface{}, error)
 	DeleteVM(VMCID) error
 
 	CalculateVMCloudProperties(VMResources) (VMCloudProps, error)

--- a/docs/example.go
+++ b/docs/example.go
@@ -29,7 +29,7 @@ func main() {
 
 // Empty CPI implementation
 
-func (f CPIFactory) New(_ apiv1.CallContext) (apiv1.CPI, error) {
+func (f CPIFactory) New(_ apiv1.CallContext, _ apiv1.ApiVersions) (apiv1.CPI, error) {
 	return CPI{}, nil
 }
 
@@ -48,8 +48,12 @@ func (c CPI) DeleteStemcell(cid apiv1.StemcellCID) error {
 func (c CPI) CreateVM(
 	agentID apiv1.AgentID, stemcellCID apiv1.StemcellCID,
 	cloudProps apiv1.VMCloudProps, networks apiv1.Networks,
-	associatedDiskCIDs []apiv1.DiskCID, env apiv1.VMEnv) (apiv1.VMCID, error) {
+	associatedDiskCIDs []apiv1.DiskCID, env apiv1.VMEnv,
+	apiVersions apiv1.ApiVersions) (interface{}, error) {
 
+	if apiVersions.Contract == 2 {
+		return []interface{}{apiv1.NewVMCID("vm-cid")}, nil
+	}
 	return apiv1.NewVMCID("vm-cid"), nil
 }
 
@@ -57,7 +61,7 @@ func (c CPI) DeleteVM(cid apiv1.VMCID) error {
 	return nil
 }
 
-func (c CPI) CalculateVMCloudProperties(res VMResources) (apiv1.VMCloudProps, error) {
+func (c CPI) CalculateVMCloudProperties(res apiv1.VMResources) (apiv1.VMCloudProps, error) {
 	return apiv1.NewVMCloudPropsFromMap(map[string]interface{}{}), nil
 }
 
@@ -87,8 +91,8 @@ func (c CPI) DeleteDisk(cid apiv1.DiskCID) error {
 	return nil
 }
 
-func (c CPI) AttachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {
-	return nil
+func (c CPI) AttachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) (interface{}, error) {
+	return "diskhint", nil
 }
 
 func (c CPI) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -1,0 +1,15 @@
+package rpc
+
+type DefaultContext struct {
+	DirectorUUID string    `json:"director_uuid"`
+	RequestID    string    `json:"request_id"`
+	Vm           VmContext `json:"vm"`
+}
+
+type VmContext struct {
+	Stemcell StemcellContext `json:"stemcell"`
+}
+
+type StemcellContext struct {
+	ApiVersion int `json:"api_version"`
+}

--- a/rpc/factory_test.go
+++ b/rpc/factory_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Factory", func() {
 	BeforeEach(func() {
 		cpi = &apiv1fakes.FakeCPI{}
 		cpiFactory = &apiv1fakes.FakeCPIFactory{
-			NewStub: func(_ apiv1.CallContext) (apiv1.CPI, error) { return cpi, nil },
+			NewStub: func(_ apiv1.CallContext, _ apiv1.ApiVersions) (apiv1.CPI, error) { return cpi, nil },
 		}
 
 		logger := boshlog.NewLogger(boshlog.LevelNone)
@@ -52,11 +52,11 @@ var _ = Describe("Factory", func() {
 		return resp, string(outBytes)
 	}
 
-	Describe("cpi context", func() {
+	Describe("cpi new", func() {
 		It("works", func() {
 			act(`{"method":"info", "arguments":[], "context": {"cp1": "cp1-val"}}`)
 
-			ctx := cpiFactory.NewArgsForCall(0)
+			ctx, _ := cpiFactory.NewArgsForCall(0)
 
 			var cp FakeCPs
 			Expect(ctx.As(&cp)).ToNot(HaveOccurred())
@@ -430,10 +430,10 @@ var _ = Describe("Factory", func() {
 
 	Describe("attach_disk", func() {
 		It("works", func() {
-			cpi.AttachDiskReturns(nil)
+			cpi.AttachDiskReturns("/dev/sdf", nil)
 
 			resp, _ := act(`{"method":"attach_disk", "arguments":["vm-cid", "disk-cid"]}`)
-			Expect(resp).To(Equal(Response{Result: nil}))
+			Expect(resp).To(Equal(Response{Result: "/dev/sdf"}))
 
 			vmCID, diskCID := cpi.AttachDiskArgsForCall(0)
 			Expect(vmCID).To(Equal(apiv1.NewVMCID("vm-cid")))
@@ -441,7 +441,7 @@ var _ = Describe("Factory", func() {
 		})
 
 		It("errs", func() {
-			cpi.AttachDiskReturns(errors.New("err"))
+			cpi.AttachDiskReturns("/dev/sdf", errors.New("err"))
 
 			resp, _ := act(`{"method":"attach_disk", "arguments":["vm-cid", "disk-cid"]}`)
 			Expect(resp).To(Equal(Response{Error: &ResponseError{Type: "Bosh::Clouds::CloudError", Message: "err"}}))

--- a/rpc/interfaces.go
+++ b/rpc/interfaces.go
@@ -4,8 +4,10 @@ import (
 	"github.com/cppforlife/bosh-cpi-go/apiv1"
 )
 
+//go:generate counterfeiter -o rpcfakes/fake_action_factory.go . ActionFactory
+
 type ActionFactory interface {
-	Create(string, apiv1.CallContext) (interface{}, error)
+	Create(string, apiv1.CallContext, apiv1.ApiVersions) (interface{}, error)
 }
 
 type Dispatcher interface {

--- a/rpc/rpcfakes/fake_action_factory.go
+++ b/rpc/rpcfakes/fake_action_factory.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeActionFactory struct {
-	CreateStub        func(string, apiv1.CallContext) (interface{}, error)
+	CreateStub        func(string, apiv1.CallContext, apiv1.ApiVersions) (interface{}, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 string
 		arg2 apiv1.CallContext
+		arg3 apiv1.ApiVersions
 	}
 	createReturns struct {
 		result1 interface{}
@@ -23,18 +24,20 @@ type FakeActionFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeActionFactory) Create(arg1 string, arg2 apiv1.CallContext) (interface{}, error) {
+func (fake *FakeActionFactory) Create(arg1 string, arg2 apiv1.CallContext, arg3 apiv1.ApiVersions) (interface{}, error) {
 	fake.createMutex.Lock()
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		arg1 string
 		arg2 apiv1.CallContext
-	}{arg1, arg2})
-	fake.recordInvocation("Create", []interface{}{arg1, arg2})
+		arg3 apiv1.ApiVersions
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3})
 	fake.createMutex.Unlock()
 	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2)
+		return fake.CreateStub(arg1, arg2, arg3)
+	} else {
+		return fake.createReturns.result1, fake.createReturns.result2
 	}
-	return fake.createReturns.result1, fake.createReturns.result2
 }
 
 func (fake *FakeActionFactory) CreateCallCount() int {
@@ -43,10 +46,10 @@ func (fake *FakeActionFactory) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeActionFactory) CreateArgsForCall(i int) (string, apiv1.CallContext) {
+func (fake *FakeActionFactory) CreateArgsForCall(i int) (string, apiv1.CallContext, apiv1.ApiVersions) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
-	return fake.createArgsForCall[i].arg1, fake.createArgsForCall[i].arg2
+	return fake.createArgsForCall[i].arg1, fake.createArgsForCall[i].arg2, fake.createArgsForCall[i].arg3
 }
 
 func (fake *FakeActionFactory) CreateReturns(result1 interface{}, result2 error) {


### PR DESCRIPTION
- `create_vm` return value relaxed to interface{} to allow for proposed array of [vm_cid, networks] as per v2 [registry removal](https://github.com/cloudfoundry/bosh-notes/blob/master/proposals/registry-removal.md) 
- `attach_disk` can return a value in addition to an error
- a top level api versions context has been added to existing request schema. stemcell version and target API contract version are accepted. Stemcell version is used to determine registry usage, API version used to determine responses
- update fakes etc

known issue: package is called apiv1 still